### PR TITLE
Forcing use of `include_block` instead of overriding rendering for LinkBlock

### DIFF
--- a/omni_blocks/blocks.py
+++ b/omni_blocks/blocks.py
@@ -110,9 +110,7 @@ class LinkBlock(blocks.StructBlock):
     def render(self, value, context=None):
         """Override the render to get around the above dunder string issue."""
         rendered = super(LinkBlock, self).render(value, context=context)
-        if rendered.endswith('\n'):
-            return rendered[:-1]
-        return rendered
+        return rendered.strip()
 
     class Meta:
         """Wagtail properties."""

--- a/omni_blocks/blocks.py
+++ b/omni_blocks/blocks.py
@@ -107,39 +107,17 @@ class LinkBlock(blocks.StructBlock):
 
         return cleaned_data
 
-    @staticmethod
-    def get_url_from_value(value):
-        """Conditional logic which determines whether which URL to render.
-
-        Replaces the logic that was previously rendering in the link_block template.
-        """
-        if isinstance(value, str):
-            return value
-        elif 'external_url' in value:
-            return value['external_url']
-        elif 'internal_url' in value:
-            return value['internal_url'].url
-        return ''
-
-    def to_python(self, value):
-        """Override the to_python method to avoid the built in wagtail rendering mechanisms.
-
-        The change made in Wagtail 1.12 here: https://github.com/wagtail/wagtail/commit/8a055addad739ff73f6e84ba553b28389122299f
-        has broken how we have implemented this block, as StructValue no longer implements __str__
-        we get the literal value instead: `StructValue([('external_url', 'https://omni-digital.co.uk'), ('internal_url', None)])`
-        when rendering through a template.
-
-        This override ensures that nested representations of this StructBlock render as expected.
-        """
-        return self.get_url_from_value(value)
-
     def render(self, value, context=None):
         """Override the render to get around the above dunder string issue."""
-        return self.get_url_from_value(value)
+        rendered = super(LinkBlock, self).render(value, context=context)
+        if rendered.endswith('\n'):
+            return rendered[:-1]
+        return rendered
 
     class Meta:
         """Wagtail properties."""
         label = 'Link'
+        template = 'blocks/link_block.html'
 
 
 class TitledLinkBlock(blocks.StructBlock):

--- a/omni_blocks/templates/blocks/basic_card_block.html
+++ b/omni_blocks/templates/blocks/basic_card_block.html
@@ -1,5 +1,4 @@
-{% load wagtailcore_tags %}
-{% load wagtailimages_tags %}
+{% load wagtailcore_tags wagtailimages_tags %}
 
 <section class="card">
     <header class="card_header">

--- a/omni_blocks/templates/blocks/basic_card_block.html
+++ b/omni_blocks/templates/blocks/basic_card_block.html
@@ -1,8 +1,9 @@
+{% load wagtailcore_tags %}
 {% load wagtailimages_tags %}
 
 <section class="card">
     <header class="card_header">
-      <a href="{{ self.link }}">{{ self.title }}</a>
+      <a href="{% include_block self.link %}">{{ self.title }}</a>
     </header>
 
     {% if self.image %}

--- a/omni_blocks/templates/blocks/link_block.html
+++ b/omni_blocks/templates/blocks/link_block.html
@@ -1,0 +1,7 @@
+{% spaceless %}
+{% if self.external_url %}
+    {{ self.external_url }}
+{% else %}
+    {{ self.internal_url.url }}
+{% endif %}
+{% endspaceless %}

--- a/tests/test_blocks.py
+++ b/tests/test_blocks.py
@@ -203,7 +203,7 @@ class TestLinkBlock(TestCase):
         link_block = internal_blocks.LinkBlock()
         value = link_block.to_python({
             'external_url': 'https://omni-digital.co.uk',
-            'internal_url': self.page,
+            'internal_url': self.page.pk,
         })
         content = link_block.render(value)
         self.assertEqual('https://omni-digital.co.uk', content)
@@ -216,33 +216,17 @@ class TestLinkBlock(TestCase):
                 'title': 'cool',
                 'link': {
                     'external_url': 'https://omni-digital.co.uk',
-                    'internal_url': self.page,
+                    'internal_url': self.page.pk,
                 }
             }
         )
         card_content = bc_block.render(value)
         self.assertIn('<a href="https://omni-digital.co.uk">cool</a>', card_content)
 
-    def test_get_url_from_value(self):
-        """Ensure that the get_url_from_value method is behaving as expected."""
-        test_cases = [
-            ('cool', 'cool'),
-            ({'bad': ''}, ''),
-            ({'external_url': 'https://omni-digital.co.uk'}, 'https://omni-digital.co.uk'),
-            ({'internal_url': self.page}, '/omni-digital/'),
-            ({
-                 'internal_url': self.page,
-                 'external_url': 'https://google.com',
-             }, 'https://google.com'),
-        ]
-
-        for tc in test_cases:
-            self.assertEqual(internal_blocks.LinkBlock.get_url_from_value(tc[0]), tc[1])
-
     def test_internal_url_renders(self):
         """Ensure that the internal_url renders as expected."""
         link_block = internal_blocks.LinkBlock()
-        value = link_block.to_python({
+        value = link_block.render({
             'internal_url': self.page,
         })
         self.assertEqual(value, '/omni-digital/')
@@ -254,7 +238,7 @@ class TestLinkBlock(TestCase):
             {
                 'title': 'cool',
                 'link': {
-                    'internal_url': self.page,
+                    'internal_url': self.page.pk,
                 }
             }
         )


### PR DESCRIPTION
Off the back of https://github.com/omni-digital/omni-blocks/pull/7

I discovered that the fix in that branch has broken some administrative functionality, as a result this is just going to have to be a breaking change and affected sites will need to manually update from 
`{{ link }}` to `{% include_block link %}`.
