### PR TITLE
Adding a "required" kwarg to LinkBlock

### DIFF
--- a/omni_blocks/blocks/struct_blocks.py
+++ b/omni_blocks/blocks/struct_blocks.py
@@ -27,8 +27,18 @@ class LinkBlock(blocks.StructBlock):
         """
         required = kwargs.pop('required', True)
         super(LinkBlock, self).__init__(**kwargs)
-        self._either_required = required
+        self._required = required
 
+    @property
+    def required(self):
+        """Override base block required function to return our custom kwarg.
+
+        The StructBlock class in wagtail has no logic for what is "required",
+        as such we must override the method in the base Block class.
+
+        https://github.com/wagtail/wagtail/blob/master/wagtail/core/blocks/base.py#L315
+        """
+        return self._required
 
     def clean(self, value):
         cleaned_data = super(LinkBlock, self).clean(value)
@@ -37,7 +47,7 @@ class LinkBlock(blocks.StructBlock):
             msg = self.both_urls_error
             errors['external_url'] = errors['internal_url'] = ValidationError(msg)
 
-        if self._either_required:
+        if self.required:
             if not cleaned_data.get('external_url') and not cleaned_data.get('internal_url'):
                 msg = self.no_urls_error
                 errors['external_url'] = errors['internal_url'] = ValidationError(msg)

--- a/omni_blocks/blocks/struct_blocks.py
+++ b/omni_blocks/blocks/struct_blocks.py
@@ -10,12 +10,25 @@ from omni_blocks.blocks.text_blocks import HBlock
 
 
 class LinkBlock(blocks.StructBlock):
-    """Block for adding links."""
+    """Block for adding links.
+
+    If required is set to false, we assume that a link does not need to be present.
+    """
     external_url = URLBlock(required=False)
     internal_url = blocks.PageChooserBlock(icon='doc-empty-inverse', required=False)
 
     both_urls_error = _('Please select either internal URL or external URL, not both.')
     no_urls_error = _('Please select an internal URL or add an external URL.')
+
+    def __init__(self, **kwargs):
+        """Override init to retrieve required value.
+
+        StructBlock does not have a "required" value in WagtailCore.
+        """
+        required = kwargs.pop('required', True)
+        super(LinkBlock, self).__init__(**kwargs)
+        self._either_required = required
+
 
     def clean(self, value):
         cleaned_data = super(LinkBlock, self).clean(value)
@@ -24,9 +37,10 @@ class LinkBlock(blocks.StructBlock):
             msg = self.both_urls_error
             errors['external_url'] = errors['internal_url'] = ValidationError(msg)
 
-        if not cleaned_data.get('external_url') and not cleaned_data.get('internal_url'):
-            msg = self.no_urls_error
-            errors['external_url'] = errors['internal_url'] = ValidationError(msg)
+        if self._either_required:
+            if not cleaned_data.get('external_url') and not cleaned_data.get('internal_url'):
+                msg = self.no_urls_error
+                errors['external_url'] = errors['internal_url'] = ValidationError(msg)
 
         if errors:
             raise ValidationError(msg, params=errors)

--- a/tests/test_struct_blocks.py
+++ b/tests/test_struct_blocks.py
@@ -100,6 +100,14 @@ class TestLinkBlock(TestCase):
 
         self.assertIn(self.block.no_urls_error, context.exception.messages)
 
+    def test_data_validation_link_not_required(self):
+        """Ensure that if the block is not required, we don't raise validation errors."""
+        unrequired_block = struct_blocks.LinkBlock(required=False)
+        try:
+            unrequired_block.clean({'external_url': None, 'internal_url': None})
+        except ValidationError as e:
+            self.fail('LinkBlock clean raised exception when not required and links are empty.')
+
     def test_data_validation(self):
         """Ensure that the data is validated as expected."""
         key = 'external_url'


### PR DESCRIPTION
Had a dig through Wagtail core and it seems like StructBlocks don't support a "required" kwarg out of the box. As such, one has been implemented.

* IF  both links are blank and the block is not required, do not throw a validation error.

Defaults to True to maintain current expected functionality.