### PR TITLE
Add slugified ID to heading block, allow heading block to take a template

### DIFF
--- a/omni_blocks/blocks/text_blocks.py
+++ b/omni_blocks/blocks/text_blocks.py
@@ -7,10 +7,15 @@ from wagtail.core.blocks import BlockQuoteBlock, CharBlock
 
 class HBlock(CharBlock):
     """A block for displaying headings."""
-
-    def __init__(self, tag, icon="title", classname="title", *args, **kwargs):
+    def __init__(self, tag, icon='title', classname='title', slugified_id=False, *args, **kwargs):
         self.tag = tag
-        super(HBlock, self).__init__(icon=icon, classname=classname, *args, **kwargs)
+        self.slugified_id = slugified_id
+        super(HBlock, self).__init__(
+            icon=icon,
+            classname=classname,
+            *args,
+            **kwargs
+        )
 
     def render(self, value, context=None):
         """
@@ -19,11 +24,16 @@ class HBlock(CharBlock):
         :param value: The value from the database to render
         :return: Safe String - Rendered block content
         """
-        return mark_safe(
-            "<{tag}>{contents}</{tag}>".format(
-                tag=self.tag, contents=self.render_basic(value, context=context)
-            )
-        )
+        if self.slugified_id:
+            html_string = '<{tag} id="{id}">{contents}</{tag}>'
+        else:
+            html_string = '<{tag}>{contents}</{tag}>'
+        contents=self.render_basic(value, context=context)
+        return mark_safe(html_string.format(
+            tag=self.tag,
+            id=slugify(contents),
+            contents=contents
+        ))
 
 
 class JumpHBlock(CharBlock):

--- a/omni_blocks/blocks/text_blocks.py
+++ b/omni_blocks/blocks/text_blocks.py
@@ -6,34 +6,39 @@ from wagtail.core.blocks import BlockQuoteBlock, CharBlock
 
 
 class HBlock(CharBlock):
-    """A block for displaying headings."""
-    def __init__(self, tag, icon='title', classname='title', slugified_id=False, *args, **kwargs):
+    """A block for displaying headings, with ID for use in anchors."""
+    def __init__(
+        self,
+        tag,
+        icon='title',
+        classname='title',
+        slugified_id=False,
+        *args,
+        **kwargs,
+    ):
         self.tag = tag
         self.slugified_id = slugified_id
         super(HBlock, self).__init__(
             icon=icon,
             classname=classname,
             *args,
-            **kwargs
+            **kwargs,
         )
 
-    def render(self, value, context=None):
-        """
-        Renders the block contents and returns them as a safe string.
-
-        :param value: The value from the database to render
-        :return: Safe String - Rendered block content
-        """
+    def get_context(self, value, parent_context=None):
+        """Add the tag, content, and slugified ID into our context."""
+        context = super(HBlock, self).get_context(
+            value,
+            parent_context=parent_context,
+        )
+        context['tag'] = self.tag
         if self.slugified_id:
-            html_string = '<{tag} id="{id}">{contents}</{tag}>'
-        else:
-            html_string = '<{tag}>{contents}</{tag}>'
-        contents=self.render_basic(value, context=context)
-        return mark_safe(html_string.format(
-            tag=self.tag,
-            id=slugify(contents),
-            contents=contents
-        ))
+            context['slugified_id'] = slugify(value)
+        return context
+
+    class Meta:
+        template = 'blocks/heading.html'
+
 
 
 class JumpHBlock(CharBlock):

--- a/omni_blocks/templates/blocks/heading.html
+++ b/omni_blocks/templates/blocks/heading.html
@@ -1,0 +1,6 @@
+<{{ tag }}
+{% if slugified_id %}
+    id="{{ slugified_id }}"
+{% endif %}>
+    {{ value }}
+</{{ tag }}>


### PR DESCRIPTION
This allows us to override the heading template in projects, and provides a slugified ID for crating anchor links if required.